### PR TITLE
Fix MST 3.12.0 type incompatibility causing problems in #17

### DIFF
--- a/src/classy-mst.ts
+++ b/src/classy-mst.ts
@@ -18,7 +18,7 @@ import {
   * callable to construct a specialized instance. */
 
 export interface ModelInterface<PROPS extends ModelProperties, OTHERS, CustomC, CustomS> {
-	new(): IStateTreeNode & IModelType<PROPS, OTHERS, CustomC, CustomS> & ModelInstanceType<PROPS, OTHERS, CustomC, CustomS>;
+	new(): IStateTreeNode & IModelType<PROPS, OTHERS, CustomC, CustomS> & ModelInstanceType<PROPS, OTHERS>;
 }
 
 export let typeTag: string | undefined = '$';


### PR DESCRIPTION
Types changed in MST 3.12.0 and model inheritance got broken. This change fixed it for me. 
